### PR TITLE
Remove exposed secrets from .env

### DIFF
--- a/.env
+++ b/.env
@@ -16,15 +16,15 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev
-APP_SECRET=a04a120e8bf8dc10bf7a3d6ef7e0460d
+APP_SECRET=CHANGE_ME_IN_PRODUCTION
 ###< symfony/framework-bundle ###
 
 MYSQL_DATABASE=products
 MYSQL_USER=products_user
-MYSQL_PASSWORD=products_password
-MYSQL_ROOT_PASSWORD=products_root_password
+MYSQL_PASSWORD=CHANGE_ME
+MYSQL_ROOT_PASSWORD=CHANGE_ME
 
-DATABASE_URL="mysql://products_user:products_password@products_mysql:3306/products?serverVersion=8.0"
+DATABASE_URL="mysql://products_user:CHANGE_ME@products_mysql:3306/products?serverVersion=8.0"
 
 FRAMEWORK_IDE=phpstorm
 
@@ -34,7 +34,7 @@ DOMAIN_SCHEME=http
 ###> lexik/jwt-authentication-bundle ###
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
-JWT_PASSPHRASE=e28777d28e781068329704b7da777b0f915a88c200a701ff96fa805b46b240c5
+JWT_PASSPHRASE=CHANGE_ME_IN_PRODUCTION
 ###< lexik/jwt-authentication-bundle ###
 
 ###> symfony/messenger ###


### PR DESCRIPTION
## Summary

The `.env` file contained hardcoded secrets that were exposed in version control:

- **APP_SECRET**: Symfony application secret (`a04a120e...`)
- **JWT_PASSPHRASE**: JWT signing passphrase (`e28777d2...`)
- **MYSQL_PASSWORD**: Database password
- **MYSQL_ROOT_PASSWORD**: Database root password
- **DATABASE_URL**: Contained the database password inline

All of these have been replaced with `CHANGE_ME` / `CHANGE_ME_IN_PRODUCTION` placeholders.

## Recommended Actions

1. **Rotate all exposed secrets immediately** -- since they were committed to git history, they should be considered compromised.
2. Generate a new `APP_SECRET` (e.g., `php -r "echo bin2hex(random_bytes(16));"`)
3. Generate a new `JWT_PASSPHRASE` and regenerate JWT keys
4. Change all MySQL passwords
5. Store real secrets in `.env.local` (already in `.gitignore`) or use environment variables in production
