### PR TITLE
Seguridad: corrige la autenticación JWT rota en el firewall api_auth

### DIFF
--- a/.env
+++ b/.env
@@ -16,7 +16,7 @@
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev
-APP_SECRET=a04a120e8bf8dc10bf7a3d6ef7e0460d
+APP_SECRET=ChangeMeInEnvLocal_DoNotUseInProduction
 ###< symfony/framework-bundle ###
 
 MYSQL_DATABASE=products
@@ -34,7 +34,7 @@ DOMAIN_SCHEME=http
 ###> lexik/jwt-authentication-bundle ###
 JWT_SECRET_KEY=%kernel.project_dir%/config/jwt/private.pem
 JWT_PUBLIC_KEY=%kernel.project_dir%/config/jwt/public.pem
-JWT_PASSPHRASE=e28777d28e781068329704b7da777b0f915a88c200a701ff96fa805b46b240c5
+JWT_PASSPHRASE=ChangeMeInEnvLocal_DoNotUseInProduction
 ###< lexik/jwt-authentication-bundle ###
 
 ###> symfony/messenger ###

--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -14,14 +14,16 @@ security:
             pattern: ^/(_(profiler|wdt)|css|images|js)/
             security: false
         api_area_usuario:
-            pattern: ^/area-usuario/
+            pattern: ^/api/area-usuario/
             stateless: true
             provider: api_area_usuario
             jwt: ~
             host: '%api_domain%'
         api_auth:
             provider: api_area_usuario
+            stateless: true
             host: '%api_domain%'
+            jwt: ~
             json_login:
                 check_path: api_login
                 username_path: email
@@ -31,6 +33,7 @@ security:
 
     access_control:
         - { path: ^/api/area-usuario/, roles: ROLE_WEB, host: '%api_domain%' }
+        - { path: ^/api/form/, roles: ROLE_WEB, host: '%api_domain%' }
 
 when@test:
     security:

--- a/src/App/Domain/ValueObject/Repository/OrderBy/Field.php
+++ b/src/App/Domain/ValueObject/Repository/OrderBy/Field.php
@@ -9,6 +9,7 @@ use InvalidArgumentException;
 use function implode;
 use function in_array;
 use function mb_strtoupper;
+use function preg_match;
 use function sprintf;
 
 final class Field
@@ -18,6 +19,8 @@ final class Field
         'DESC',
     ];
 
+    private const NAME_PATTERN = '/^[a-zA-Z_][a-zA-Z0-9_]*$/';
+
     private string $name;
 
     private string $direction;
@@ -26,6 +29,12 @@ final class Field
     {
         if (empty($name)) {
             throw new InvalidArgumentException('Name can not be empty');
+        }
+
+        if (! preg_match(self::NAME_PATTERN, $name)) {
+            throw new InvalidArgumentException(
+                sprintf('Name "%s" is not a valid field name', $name)
+            );
         }
 
         $direction = mb_strtoupper($direction);


### PR DESCRIPTION
Revisión de seguridad de la API Symfony 6.4 (DDD + CQRS).

## Cambios

**🔴 Alto — Autenticación rota: los tokens JWT nunca se validaban**
- `config/packages/security.yaml`: el firewall `api_auth` (que cubre `/api/form/*`, `/api/productos/*`, `/api/users/*`) **no tenía autenticador `jwt:` ni `stateless: true`**, sólo `json_login` para la propia ruta de login. En la práctica los Bearer tokens no se validaban en ninguna otra petición: `POST /api/form/{tipoForm}` (creación de productos, documentada en el README como que requiere autenticación) era alcanzable por cualquiera y además reventaba con un `TypeError` no capturado (`UserWebTransformer::transform(null)`) en lugar de devolver 401. Tampoco había ninguna regla de `access_control` que protegiera esa ruta.
- Añadidos `stateless: true` y `jwt: ~` al firewall, más una regla de `access_control` que exige `ROLE_WEB` en `^/api/form/`.

**🟠 Firewall muerto por patrón incorrecto**
- Mismo fichero: el patrón del firewall `api_area_usuario` era `^/area-usuario/` cuando la ruta real es `^/api/area-usuario/` (por el `%api_route_prefix%=/api`), así que esa comprobación JWT **nunca llegaba a aplicarse** a tráfico real. Corregido.

**🟠 Secretos commiteados**
- `.env` (trackeado en git) contenía un `APP_SECRET` y un `JWT_PASSPHRASE` con pinta de reales (hex aleatorio, no placeholders evidentes), contradiciendo el propio comentario del fichero ("DO NOT DEFINE PRODUCTION SECRETS"). Sustituidos por placeholders.

**🟡 Inyección SQL latente**
- `src/App/Domain/ValueObject/Repository/OrderBy/Field.php`: `$name` se aceptaba sin validar y luego se interpolaba vía `sprintf('%s.%s ...')` directamente en SQL crudo en `OrderBy::rawSql()`. Hoy es código muerto, pero no había ninguna whitelist protegiéndolo. Añadida una validación por regex del nombre de campo.

## ⚠️ Acción requerida

**Rota el `APP_SECRET` y el `JWT_PASSPHRASE`** allá donde se hayan podido reutilizar: siguen en el historial de git. Rotar la passphrase implica regenerar el par de claves JWT (`lexik:jwt:generate-keypair`), lo que invalidará los tokens existentes.

## Pendiente (no aplicado)

- **Dependencias**: `composer.lock` fija symfony/* 6.4.3–6.4.6, api-platform/core 2.7.18, doctrine/orm 2.19.3, lexik/jwt-authentication-bundle 2.20.3 — varias releases por detrás. GitHub reporta **42 vulnerabilidades** (1 crítica / 12 altas / 14 moderadas / 15 bajas). Requiere `composer update`; no he editado el lockfile a mano.
  - Nota: CVE-2026-49858 (fuga de caché en los normalizers JSON:API/HAL de api-platform) **no aplica** aquí, porque sólo está habilitado el formato `json` y la app corre bajo php-fpm/Apache clásico, no un worker persistente.
- Las credenciales de MySQL en `docker-compose.yml`/`.env.test` son defaults locales de Docker (riesgo bajo), pero conviene endurecerlas para cualquier despliegue no local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KPEv8PeWKJjoR6wvxGNNQc

---
_Generated by [Claude Code](https://claude.ai/code/session_01KPEv8PeWKJjoR6wvxGNNQc)_